### PR TITLE
Bucket tags editor in Catalog Services added

### DIFF
--- a/tile.yml
+++ b/tile.yml
@@ -144,16 +144,16 @@ packages:
 # Properties specified here will not be configurable by the user.
 #
 properties:
- - name: catalog_services_0_guid
-   type: uuid
- - name: catalog_services_1_guid
-   type: uuid
- - name: catalog_services_2_guid
-   type: uuid
- - name: catalog_services_3_guid
-   type: uuid
- - name: catalog_services_4_guid
-   type: uuid
+- name: catalog_services_0_guid
+  type: uuid
+- name: catalog_services_1_guid
+  type: uuid
+- name: catalog_services_2_guid
+  type: uuid
+- name: catalog_services_3_guid
+  type: uuid
+- name: catalog_services_4_guid
+  type: uuid
 #   type: string
 #   default: specify a value
 #   label: Label for the field on the GUI
@@ -380,6 +380,19 @@ forms:
         optional: true
         configurable: true
         description: (Optional) Namespace for buckets. If empty, buckets will be created in namespace specified in ECS Connection Details
+      - name: bucket_tags
+        label: Bucket Tags
+        type: string
+        optional: true
+        configurable: true
+        description: (Optional) Tags for buckets. Represented as key-value pairs in format 'key1=value1,key2=value2'
+        constraints:
+          - must_match_regex: '^[\w\d\+\-\.\_\:\/\@\s\=\,]*$'
+            error_message: 'Allowed characters are letters, numbers, and spaces representable in UTF-8, and the following characters: + - . _ : / @'
+          - must_match_regex: '^(.{0,128}\s?=\s?.{0,256}\s?,\s?)*.{0,128}\s?=\s?.{0,256}$|^$'
+            error_message: 'A tag key can be up to 128 Unicode characters in length, and tag values can be up to 256 Unicode characters in length'
+          - must_match_regex: '^([\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}\s?,\s?)*[\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}$|^$'
+            error_message: Tag pairs should be presented in format 'key1=value1,key2=value2'
     - name: namespace_option
       select_value: Namespace
       property_blueprints:
@@ -507,6 +520,19 @@ forms:
       optional: true
       configurable: true
       description: The default object number of seconds an object should be retained. The object cannot be deleted until that time has elapsed. This can be set to -1 for infinite retention. This only applies to bucket services
+    - name: bucket_tags
+      label: Bucket Tags
+      type: string
+      optional: true
+      configurable: true
+      description: (Optional) Tags for buckets. Represented as key-value pairs in format 'key1=value1,key2=value2'
+      constraints:
+        - must_match_regex: '^[\w\d\+\-\.\_\:\/\@\s\=\,]*$'
+          error_message: 'Allowed characters are letters, numbers, and spaces representable in UTF-8, and the following characters: + - . _ : / @'
+        - must_match_regex: '^(.{0,128}\s?=\s?.{0,256}\s?,\s?)*.{0,128}\s?=\s?.{0,256}$|^$'
+          error_message: 'A tag key can be up to 128 Unicode characters in length, and tag values can be up to 256 Unicode characters in length'
+        - must_match_regex: '^([\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}\s?,\s?)*[\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}$|^$'
+          error_message: Tag pairs should be presented in format 'key1=value1,key2=value2'
     default:
     - name: 5gb
       description: 5 GB free trial
@@ -649,6 +675,19 @@ forms:
         optional: true
         configurable: true
         description: (Optional) Namespace for buckets. If empty, buckets will be created in namespace specified in ECS Connection Details
+      - name: bucket_tags
+        label: Bucket Tags
+        type: string
+        optional: true
+        configurable: true
+        description: (Optional) Tags for buckets. Represented as key-value pairs in format 'key1=value1,key2=value2'
+        constraints:
+          - must_match_regex: '^[\w\d\+\-\.\_\:\/\@\s\=\,]*$'
+            error_message: 'Allowed characters are letters, numbers, and spaces representable in UTF-8, and the following characters: + - . _ : / @'
+          - must_match_regex: '^(.{0,128}\s?=\s?.{0,256}\s?,\s?)*.{0,128}\s?=\s?.{0,256}$|^$'
+            error_message: 'A tag key can be up to 128 Unicode characters in length, and tag values can be up to 256 Unicode characters in length'
+          - must_match_regex: '^([\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}\s?,\s?)*[\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}$|^$'
+            error_message: Tag pairs should be presented in format 'key1=value1,key2=value2'
     - name: namespace_option
       select_value: Namespace
       property_blueprints:
@@ -776,6 +815,19 @@ forms:
       optional: true
       configurable: true
       description: The default object number of seconds an object should be retained. The object cannot be deleted until that time has elapsed. This can be set to -1 for infinite retention. This only applies to bucket services
+    - name: bucket_tags
+      label: Bucket Tags
+      type: string
+      optional: true
+      configurable: true
+      description: (Optional) Tags for buckets. Represented as key-value pairs in format 'key1=value1,key2=value2'
+      constraints:
+        - must_match_regex: '^[\w\d\+\-\.\_\:\/\@\s\=\,]*$'
+          error_message: 'Allowed characters are letters, numbers, and spaces representable in UTF-8, and the following characters: + - . _ : / @'
+        - must_match_regex: '^(.{0,128}\s?=\s?.{0,256}\s?,\s?)*.{0,128}\s?=\s?.{0,256}$|^$'
+          error_message: 'A tag key can be up to 128 Unicode characters in length, and tag values can be up to 256 Unicode characters in length'
+        - must_match_regex: '^([\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}\s?,\s?)*[\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}$|^$'
+          error_message: Tag pairs should be presented in format 'key1=value1,key2=value2'
     default:
     - name: 5gb
       description: 5 GB free trial
@@ -917,6 +969,19 @@ forms:
         optional: true
         configurable: true
         description: (Optional) Namespace for buckets. If empty, buckets will be created in namespace specified in ECS Connection Details
+      - name: bucket_tags
+        label: Bucket Tags
+        type: string
+        optional: true
+        configurable: true
+        description: (Optional) Tags for buckets. Represented as key-value pairs in format 'key1=value1,key2=value2'
+        constraints:
+          - must_match_regex: '^[\w\d\+\-\.\_\:\/\@\s\=\,]*$'
+            error_message: 'Allowed characters are letters, numbers, and spaces representable in UTF-8, and the following characters: + - . _ : / @'
+          - must_match_regex: '^(.{0,128}\s?=\s?.{0,256}\s?,\s?)*.{0,128}\s?=\s?.{0,256}$|^$'
+            error_message: 'A tag key can be up to 128 Unicode characters in length, and tag values can be up to 256 Unicode characters in length'
+          - must_match_regex: '^([\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}\s?,\s?)*[\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}$|^$'
+            error_message: Tag pairs should be presented in format 'key1=value1,key2=value2'
     - name: namespace_option
       select_value: Namespace
       property_blueprints:
@@ -1044,6 +1109,19 @@ forms:
       optional: true
       configurable: true
       description: The default object number of seconds an object should be retained. The object cannot be deleted until that time has elapsed. This can be set to -1 for infinite retention. This only applies to bucket services
+    - name: bucket_tags
+      label: Bucket Tags
+      type: string
+      optional: true
+      configurable: true
+      description: (Optional) Tags for buckets. Represented as key-value pairs in format 'key1=value1,key2=value2'
+      constraints:
+        - must_match_regex: '^[\w\d\+\-\.\_\:\/\@\s\=\,]*$'
+          error_message: 'Allowed characters are letters, numbers, and spaces representable in UTF-8, and the following characters: + - . _ : / @'
+        - must_match_regex: '^(.{0,128}\s?=\s?.{0,256}\s?,\s?)*.{0,128}\s?=\s?.{0,256}$|^$'
+          error_message: 'A tag key can be up to 128 Unicode characters in length, and tag values can be up to 256 Unicode characters in length'
+        - must_match_regex: '^([\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}\s?,\s?)*[\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}$|^$'
+          error_message: Tag pairs should be presented in format 'key1=value1,key2=value2'
     default:
     - name: 5gb
       description: 5 GB free trial
@@ -1185,6 +1263,19 @@ forms:
         optional: true
         configurable: true
         description: (Optional) Namespace for buckets. If empty, buckets will be created in namespace specified in ECS Connection Details
+      - name: bucket_tags
+        label: Bucket Tags
+        type: string
+        optional: true
+        configurable: true
+        description: (Optional) Tags for buckets. Represented as key-value pairs in format 'key1=value1,key2=value2'
+        constraints:
+          - must_match_regex: '^[\w\d\+\-\.\_\:\/\@\s\=\,]*$'
+            error_message: 'Allowed characters are letters, numbers, and spaces representable in UTF-8, and the following characters: + - . _ : / @'
+          - must_match_regex: '^(.{0,128}\s?=\s?.{0,256}\s?,\s?)*.{0,128}\s?=\s?.{0,256}$|^$'
+            error_message: 'A tag key can be up to 128 Unicode characters in length, and tag values can be up to 256 Unicode characters in length'
+          - must_match_regex: '^([\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}\s?,\s?)*[\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}$|^$'
+            error_message: Tag pairs should be presented in format 'key1=value1,key2=value2'
     - name: namespace_option
       select_value: Namespace
       property_blueprints:
@@ -1312,6 +1403,19 @@ forms:
       optional: true
       configurable: true
       description: The default object number of seconds an object should be retained. The object cannot be deleted until that time has elapsed. This can be set to -1 for infinite retention. This only applies to bucket services
+    - name: bucket_tags
+      label: Bucket Tags
+      type: string
+      optional: true
+      configurable: true
+      description: (Optional) Tags for buckets. Represented as key-value pairs in format 'key1=value1,key2=value2'
+      constraints:
+        - must_match_regex: '^[\w\d\+\-\.\_\:\/\@\s\=\,]*$'
+          error_message: 'Allowed characters are letters, numbers, and spaces representable in UTF-8, and the following characters: + - . _ : / @'
+        - must_match_regex: '^(.{0,128}\s?=\s?.{0,256}\s?,\s?)*.{0,128}\s?=\s?.{0,256}$|^$'
+          error_message: 'A tag key can be up to 128 Unicode characters in length, and tag values can be up to 256 Unicode characters in length'
+        - must_match_regex: '^([\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}\s?,\s?)*[\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}$|^$'
+          error_message: Tag pairs should be presented in format 'key1=value1,key2=value2'
     default:
     - name: 5gb
       description: 5 GB free trial
@@ -1453,6 +1557,19 @@ forms:
         optional: true
         configurable: true
         description: (Optional) Namespace for buckets. If empty, buckets will be created in namespace specified in ECS Connection Details
+      - name: bucket_tags
+        label: Bucket Tags
+        type: string
+        optional: true
+        configurable: true
+        description: (Optional) Tags for buckets. Represented as key-value pairs in format 'key1=value1,key2=value2'
+        constraints:
+          - must_match_regex: '^[\w\d\+\-\.\_\:\/\@\s\=\,]*$'
+            error_message: 'Allowed characters are letters, numbers, and spaces representable in UTF-8, and the following characters: + - . _ : / @'
+          - must_match_regex: '^(.{0,128}\s?=\s?.{0,256}\s?,\s?)*.{0,128}\s?=\s?.{0,256}$|^$'
+            error_message: 'A tag key can be up to 128 Unicode characters in length, and tag values can be up to 256 Unicode characters in length'
+          - must_match_regex: '^([\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}\s?,\s?)*[\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}$|^$'
+            error_message: Tag pairs should be presented in format 'key1=value1,key2=value2'
     - name: namespace_option
       select_value: Namespace
       property_blueprints:
@@ -1580,6 +1697,19 @@ forms:
       optional: true
       configurable: true
       description: The default object number of seconds an object should be retained. The object cannot be deleted until that time has elapsed. This can be set to -1 for infinite retention. This only applies to bucket services
+    - name: bucket_tags
+      label: Bucket Tags
+      type: string
+      optional: true
+      configurable: true
+      description: (Optional) Tags for buckets. Represented as key-value pairs in format 'key1=value1,key2=value2'
+      constraints:
+        - must_match_regex: '^[\w\d\+\-\.\_\:\/\@\s\=\,]*$'
+          error_message: 'Allowed characters are letters, numbers, and spaces representable in UTF-8, and the following characters: + - . _ : / @'
+        - must_match_regex: '^(.{0,128}\s?=\s?.{0,256}\s?,\s?)*.{0,128}\s?=\s?.{0,256}$|^$'
+          error_message: 'A tag key can be up to 128 Unicode characters in length, and tag values can be up to 256 Unicode characters in length'
+        - must_match_regex: '^([\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}\s?,\s?)*[\w\d\+\-\.\_\:\/\@\s]{0,128}\s?=\s?[\w\d\+\-\.\_\:\/\@\s]{0,256}$|^$'
+          error_message: Tag pairs should be presented in format 'key1=value1,key2=value2'
     default:
     - name: 5gb
       description: 5 GB free trial


### PR DESCRIPTION
New string editor added in Catalog Services description UI allowing to add bucket tags to Service and Plan definition.